### PR TITLE
Fix: KeepTemporaryFiles toggled has the opposite behaviour as expected

### DIFF
--- a/SequenceRegistration/SequenceRegistration.py
+++ b/SequenceRegistration/SequenceRegistration.py
@@ -460,7 +460,7 @@ class SequenceRegistrationWidget(ScriptedLoadableModuleWidget):
     qt.QDesktopServices().openUrl(qt.QUrl("file:///" + self.logic.elastixLogic.getTempDirectoryBase(), qt.QUrl.TolerantMode));
 
   def onKeepTemporaryFilesToggled(self, toggle):
-    self.logic.elastixLogic.deleteTemporaryFiles = toggle
+    self.logic.elastixLogic.deleteTemporaryFiles = not toggle
 
   def onShowRegistrationParametersDatabaseFolder(self):
     qt.QDesktopServices().openUrl(qt.QUrl("file:///" + self.logic.elastixLogic.registrationParameterFilesDir, qt.QUrl.TolerantMode));


### PR DESCRIPTION
### Context
When registering a DCEMRI sequence, the "Keep temporary files" toggle checkbox had the opposite behaviour as expected: the temporary files got deleted when the box was checked (Toggled=True), but they were kept when unselected (Toggled=False), given this was the default behaviour, my local storage filled up quickly with the datasets I was playing around.
### Changed & Results
I inverted the behaviour of the toggle value when passed to the slicer elastix Logic function to achieve the expected result. I evaluated it successfully with Slicer 5.6.2 running on a MacBook Pro 2023, Sonoma 14.4.1.

Just let me know anything

Regards,
Jose 